### PR TITLE
Fixed segfault before entering main() issue

### DIFF
--- a/Splay Tree.c
+++ b/Splay Tree.c
@@ -209,7 +209,7 @@ int main()
     int x;
     int find[11] = {104, 112, 117, 124, 121, 108, 109, 111,
                     122, 125, 129};
-    int add[11] = {a, b, c, d, e, f, g, h, i, j, k};
+    int* add[11] = {a, b, c, d, e, f, g, h, i, j, k};
     srand(time(0));
     for (x = 0; x < 11; x++)
     {


### PR DESCRIPTION
On line 218 the node's addresses were stored as integers instead of pointers.  This resulted in a segfault before the program entered main. Changing 'int [n]' to 'int* [n]' allows the program to run flawlessly.

There are a few other changes I would love to make.  Reach out if you would like me to continue contributing on github.  Thanks and have a great day!